### PR TITLE
Use execa instead of spawn

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.yarnpkg.com

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+registry "https://registry.yarnpkg.com"

--- a/bin/ember-test-helpers-codemod.js
+++ b/bin/ember-test-helpers-codemod.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const spawn = require("child_process").spawn;
+const execa = require("execa");
 const chalk = require("chalk");
 const path = require("path");
 
@@ -9,7 +9,7 @@ try {
   let transformPath = __dirname + "/../index.js";
   let type = process.argv[2];
   let targetDir = process.argv[3];
-  spawn(binPath, ["-t", transformPath, targetDir, type], {
+  execa(binPath, ["-t", transformPath, targetDir, type], {
     stdio: "inherit",
     env: process.env
   });

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "chalk": "^1.1.3",
+    "execa": "^0.9.0",
     "jscodeshift": "^0.3.30"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1456,6 +1456,18 @@ execa@^0.7.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+execa@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.9.0.tgz#adb7ce62cf985071f60580deb4a88b9e34712d01"
+  dependencies:
+    cross-spawn "^5.0.1"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
 expand-brackets@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-0.1.5.tgz#df07284e342a807cd733ac5af72411e581d1177b"


### PR DESCRIPTION
This fixes #11 , by using `execa` instead of `child_process.spawn`.

I tried it on my Windows PC, and it worked fine!