### PR TITLE
Migrate ember-native-dom-helpers context argument usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ These transformations are available for tests based on `ember-native-dom-helpers
 |---------------------------------------|-------------------------|----------------|
 | ```import { click, find, findAll, fillIn, focus, blur, triggerEvent, keyEvent, waitFor, waitUntil } from 'ember-native-dom-helpers';``` | ```import { click, find, findAll, fillIn, focus, blur, triggerEvent, triggerKeyEvent, waitFor, waitUntil } from '@ember/test-helpers';``` |
 | `find('.foo', context)`                      | `context.querySelector('.foo')`                            |
+| `find('.foo', '.context')`                   | `find('.context .foo')`                                    |
 | `findAll('.foo', context)`                   | `context.querySelectorAll('.foo')`                         |
 | `click('.foo', context)`                     | `click(context.querySelector('.foo'))`                     |
 | `click('.foo', context, { shiftKey: true })` | `click(context.querySelector('.foo'), { shiftKey: true })` |

--- a/README.md
+++ b/README.md
@@ -98,8 +98,12 @@ These transformations are available for tests based on `ember-native-dom-helpers
 
 | Before                                | After                   | Transform      |
 |---------------------------------------|-------------------------|----------------|
-| ```import { click, find, findAll, fillIn, focus, blur, triggerEvent, keyEvent, waitFor, waitUntil } from 'ember-native-dom-helpers';``` | ```import { click, find, findAll, fillIn, focus, blur, triggerEvent, triggerKeyEvent, waitFor, waitUntil } from '@ember/test-helpers';``` | `migrate-imports.js`     |
-
+| ```import { click, find, findAll, fillIn, focus, blur, triggerEvent, keyEvent, waitFor, waitUntil } from 'ember-native-dom-helpers';``` | ```import { click, find, findAll, fillIn, focus, blur, triggerEvent, triggerKeyEvent, waitFor, waitUntil } from '@ember/test-helpers';``` |
+| `find('.foo', context)`                      | `context.querySelector('.foo')`                            |
+| `findAll('.foo', context)`                   | `context.querySelectorAll('.foo')`                         |
+| `click('.foo', context)`                     | `click(context.querySelector('.foo'))`                     |
+| `click('.foo', context, { shiftKey: true })` | `click(context.querySelector('.foo'), { shiftKey: true })` |
+ 
 
 ### Replace find/findAll
 

--- a/transforms/native-dom/__testfixtures__/context-argument.input.js
+++ b/transforms/native-dom/__testfixtures__/context-argument.input.js
@@ -1,0 +1,21 @@
+import { find, findAll, visit, click, fillIn } from 'ember-native-dom-helpers';
+import { test } from 'qunit';
+import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+
+moduleForAcceptance('click');
+
+test('visiting /foo', async function(assert) {
+  await visit('/foo');
+
+  const foo = find('.foo');
+  assert.equal(find('.bar', foo).textContent.trim(), 'bar');
+  assert.equal(find('.bar', find('.foo')).textContent.trim(), 'bar');
+  assert.equal(find('.bar', '.foo').textContent.trim(), 'bar');
+  assert.equal(findAll('.bar', foo).length, 2);
+  assert.equal(findAll('.bar', find('.foo')).length, 2);
+  assert.equal(findAll('.bar', '.foo').length, 2);
+
+  await click('button', foo);
+  await click('button', { shiftKey: true });
+  await click('button', foo, { shiftKey: true });
+});

--- a/transforms/native-dom/__testfixtures__/context-argument.output.js
+++ b/transforms/native-dom/__testfixtures__/context-argument.output.js
@@ -1,0 +1,21 @@
+import { find, findAll, visit, click, fillIn } from '@ember/test-helpers';
+import { test } from 'qunit';
+import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+
+moduleForAcceptance('click');
+
+test('visiting /foo', async function(assert) {
+  await visit('/foo');
+
+  const foo = find('.foo');
+  assert.equal(foo.querySelector('.bar').textContent.trim(), 'bar');
+  assert.equal(find('.foo').querySelector('.bar').textContent.trim(), 'bar');
+  assert.equal(find('.foo .bar').textContent.trim(), 'bar');
+  assert.equal(foo.querySelectorAll('.bar').length, 2);
+  assert.equal(find('.foo').querySelectorAll('.bar').length, 2);
+  assert.equal(findAll('.foo .bar').length, 2);
+
+  await click(foo.querySelector('button'));
+  await click('button', { shiftKey: true });
+  await click(foo.querySelector('button'), { shiftKey: true });
+});


### PR DESCRIPTION
`ember-native-dom-helpers` supports an optional context argument for a few helpers.
```js
let context = find('.foo');
find('.bar', context); // find the first matching element inside the context element
```

`@ember/test-helpers` removed them (https://github.com/emberjs/ember-test-helpers/pull/354).