### PR TITLE
update ember-test-helper-api-migration to support more case

### DIFF
--- a/transforms/acceptance/README.md
+++ b/transforms/acceptance/README.md
@@ -71,7 +71,7 @@ test('visiting /foo', function(assert) {
 
 ```
 
-**Output** (<small>[andthen.input.js](transforms/acceptance/__testfixtures__/andthen.output.js)</small>):
+**Output** (<small>[andthen.output.js](transforms/acceptance/__testfixtures__/andthen.output.js)</small>):
 ```js
 import { visit } from '@ember/test-helpers';
 import { test } from 'qunit';
@@ -110,7 +110,7 @@ test('visiting /foo', function(assert) {
 });
 ```
 
-**Output** (<small>[attr.input.js](transforms/acceptance/__testfixtures__/attr.output.js)</small>):
+**Output** (<small>[attr.output.js](transforms/acceptance/__testfixtures__/attr.output.js)</small>):
 ```js
 import { find } from '@ember/test-helpers';
 import { test } from 'qunit';
@@ -145,7 +145,7 @@ test('visiting /foo', function(assert) {
 
 ```
 
-**Output** (<small>[click.input.js](transforms/acceptance/__testfixtures__/click.output.js)</small>):
+**Output** (<small>[click.output.js](transforms/acceptance/__testfixtures__/click.output.js)</small>):
 ```js
 import { click, currentURL, findAll, visit } from '@ember/test-helpers';
 import { test } from 'qunit';
@@ -198,7 +198,7 @@ test('function callback with one arg', function(assert) {
 
 ```
 
-**Output** (<small>[each.input.js](transforms/acceptance/__testfixtures__/each.output.js)</small>):
+**Output** (<small>[each.output.js](transforms/acceptance/__testfixtures__/each.output.js)</small>):
 ```js
 import { findAll } from '@ember/test-helpers';
 import { test } from 'qunit';
@@ -253,7 +253,7 @@ test('visiting /foo', function(assert) {
 
 ```
 
-**Output** (<small>[fill-in.input.js](transforms/acceptance/__testfixtures__/fill-in.output.js)</small>):
+**Output** (<small>[fill-in.output.js](transforms/acceptance/__testfixtures__/fill-in.output.js)</small>):
 ```js
 import { fillIn, currentURL, findAll, visit } from '@ember/test-helpers';
 import { test } from 'qunit';
@@ -285,7 +285,7 @@ test('visiting /foo', function(assert) {
 });
 ```
 
-**Output** (<small>[get-value.input.js](transforms/acceptance/__testfixtures__/get-value.output.js)</small>):
+**Output** (<small>[get-value.output.js](transforms/acceptance/__testfixtures__/get-value.output.js)</small>):
 ```js
 import { find } from '@ember/test-helpers';
 import { test } from 'qunit';
@@ -315,7 +315,7 @@ test('transforms get() correctly', function(assert) {
 
 ```
 
-**Output** (<small>[get.input.js](transforms/acceptance/__testfixtures__/get.output.js)</small>):
+**Output** (<small>[get.output.js](transforms/acceptance/__testfixtures__/get.output.js)</small>):
 ```js
 import { findAll } from '@ember/test-helpers';
 import { test } from 'qunit';
@@ -345,7 +345,7 @@ test('visiting /foo', function(assert) {
 });
 ```
 
-**Output** (<small>[has-class.input.js](transforms/acceptance/__testfixtures__/has-class.output.js)</small>):
+**Output** (<small>[has-class.output.js](transforms/acceptance/__testfixtures__/has-class.output.js)</small>):
 ```js
 import { find } from '@ember/test-helpers';
 import { test } from 'qunit';
@@ -376,7 +376,7 @@ test('visiting /foo', function(assert) {
 });
 ```
 
-**Output** (<small>[html.input.js](transforms/acceptance/__testfixtures__/html.output.js)</small>):
+**Output** (<small>[html.output.js](transforms/acceptance/__testfixtures__/html.output.js)</small>):
 ```js
 import { find } from '@ember/test-helpers';
 import { test } from 'qunit';
@@ -412,7 +412,7 @@ test('visiting /foo', function(assert) {
 });
 ```
 
-**Output** (<small>[key-event.input.js](transforms/acceptance/__testfixtures__/key-event.output.js)</small>):
+**Output** (<small>[key-event.output.js](transforms/acceptance/__testfixtures__/key-event.output.js)</small>):
 ```js
 import { keyEvent, currentURL, visit } from '@ember/test-helpers';
 import { test } from 'qunit';
@@ -442,7 +442,7 @@ test('visiting /foo', function(assert) {
 });
 ```
 
-**Output** (<small>[length.input.js](transforms/acceptance/__testfixtures__/length.output.js)</small>):
+**Output** (<small>[length.output.js](transforms/acceptance/__testfixtures__/length.output.js)</small>):
 ```js
 import { findAll } from '@ember/test-helpers';
 import { test } from 'qunit';
@@ -496,7 +496,7 @@ test('visiting /twiddles', function(assert) {
 
 ```
 
-**Output** (<small>[nested-in-and-then.input.js](transforms/acceptance/__testfixtures__/nested-in-and-then.output.js)</small>):
+**Output** (<small>[nested-in-and-then.output.js](transforms/acceptance/__testfixtures__/nested-in-and-then.output.js)</small>):
 ```js
 import { click } from '@ember/test-helpers';
 import { test } from 'qunit';
@@ -536,7 +536,7 @@ test('visiting /foo', function(assert) {
 });
 ```
 
-**Output** (<small>[prop.input.js](transforms/acceptance/__testfixtures__/prop.output.js)</small>):
+**Output** (<small>[prop.output.js](transforms/acceptance/__testfixtures__/prop.output.js)</small>):
 ```js
 import { find } from '@ember/test-helpers';
 import { test } from 'qunit';
@@ -567,7 +567,7 @@ test('visiting /foo', function(assert) {
 
 ```
 
-**Output** (<small>[route-helpers.input.js](transforms/acceptance/__testfixtures__/route-helpers.output.js)</small>):
+**Output** (<small>[route-helpers.output.js](transforms/acceptance/__testfixtures__/route-helpers.output.js)</small>):
 ```js
 import { currentURL, currentPath, currentRouteName, visit } from '@ember/test-helpers';
 import { test } from 'qunit';
@@ -605,7 +605,7 @@ test(':selected is replaced correctly', function(assert) {
 
 ```
 
-**Output** (<small>[selected.input.js](transforms/acceptance/__testfixtures__/selected.output.js)</small>):
+**Output** (<small>[selected.output.js](transforms/acceptance/__testfixtures__/selected.output.js)</small>):
 ```js
 import { find, findAll } from '@ember/test-helpers';
 import { test } from 'qunit';
@@ -639,7 +639,7 @@ test('visiting /foo', function(assert) {
 });
 ```
 
-**Output** (<small>[text.input.js](transforms/acceptance/__testfixtures__/text.output.js)</small>):
+**Output** (<small>[text.output.js](transforms/acceptance/__testfixtures__/text.output.js)</small>):
 ```js
 import { find } from '@ember/test-helpers';
 import { test } from 'qunit';
@@ -673,7 +673,7 @@ test('visiting /foo', function(assert) {
 });
 ```
 
-**Output** (<small>[trigger-event.input.js](transforms/acceptance/__testfixtures__/trigger-event.output.js)</small>):
+**Output** (<small>[trigger-event.output.js](transforms/acceptance/__testfixtures__/trigger-event.output.js)</small>):
 ```js
 import { currentURL, blur, focus, triggerEvent, visit } from '@ember/test-helpers';
 import { test } from 'qunit';
@@ -726,7 +726,7 @@ test('visiting /bar', async function(assert) {
 
 ```
 
-**Output** (<small>[visit.input.js](transforms/acceptance/__testfixtures__/visit.output.js)</small>):
+**Output** (<small>[visit.output.js](transforms/acceptance/__testfixtures__/visit.output.js)</small>):
 ```js
 import { currentURL, visit } from '@ember/test-helpers';
 import { test } from 'qunit';
@@ -755,4 +755,4 @@ test('visiting /bar', async function(assert) {
 });
 
 ```
-<!--FIXTURE_CONTENT_END-->
+<!--FIXTURES_CONTENT_END-->

--- a/transforms/ember-test-helper-api-migration/README.md
+++ b/transforms/ember-test-helper-api-migration/README.md
@@ -18,6 +18,7 @@ ember-test-helpers-codemod ember-test-helper-api-migration path/of/files/ or/som
 * [basic](#basic)
 * [do-not-have-@ember-test-helpers-import](#do-not-have-@ember-test-helpers-import)
 * [do-not-have-ember-test-helpers-import](#do-not-have-ember-test-helpers-import)
+* [test-context-specifier](#test-context-specifier)
 <!--FIXTURES_TOC_END-->
 
 <!--FIXTURES_CONTENT_START-->
@@ -29,12 +30,24 @@ ember-test-helpers-codemod ember-test-helper-api-migration path/of/files/ or/som
 import { setApplication } from '@ember/test-helpers';
 import { start } from 'ember-qunit';
 import { setResolver } from 'ember-test-helpers';
+
+setResolver(engineResolverFor('shared-components'));
+
+setApplication(Application.create(config.APP));
+preloadAssets(manifest).then(start);
+
 ```
 
-**Output** (<small>[basic.input.js](transforms/ember-test-helper-api-migration/__testfixtures__/basic.output.js)</small>):
+**Output** (<small>[basic.output.js](transforms/ember-test-helper-api-migration/__testfixtures__/basic.output.js)</small>):
 ```js
 import { setApplication, setResolver } from '@ember/test-helpers';
 import { start } from 'ember-qunit';
+
+setResolver(engineResolverFor('shared-components'));
+
+setApplication(Application.create(config.APP));
+preloadAssets(manifest).then(start);
+
 ```
 ---
 <a id="do-not-have-@ember-test-helpers-import">**do-not-have-@ember-test-helpers-import**</a>
@@ -43,12 +56,24 @@ import { start } from 'ember-qunit';
 ```js
 import { start } from 'ember-qunit';
 import { setResolver } from 'ember-test-helpers';
+
+setResolver(engineResolverFor('shared-components')); 
+ 
+setApplication(Application.create(config.APP)); 
+preloadAssets(manifest).then(start); 
+
 ```
 
-**Output** (<small>[do-not-have-@ember-test-helpers-import.input.js](transforms/ember-test-helper-api-migration/__testfixtures__/do-not-have-@ember-test-helpers-import.output.js)</small>):
+**Output** (<small>[do-not-have-@ember-test-helpers-import.output.js](transforms/ember-test-helper-api-migration/__testfixtures__/do-not-have-@ember-test-helpers-import.output.js)</small>):
 ```js
 import { setResolver } from '@ember/test-helpers';
 import { start } from 'ember-qunit';
+
+setResolver(engineResolverFor('shared-components')); 
+ 
+setApplication(Application.create(config.APP)); 
+preloadAssets(manifest).then(start); 
+
 ```
 ---
 <a id="do-not-have-ember-test-helpers-import">**do-not-have-ember-test-helpers-import**</a>
@@ -61,9 +86,10 @@ import hbs from 'htmlbars-inline-precompile';
 moduleForComponent('foo-bar', 'Integration | Component | foo bar', {
   integration: true
 });
+
 ```
 
-**Output** (<small>[do-not-have-ember-test-helpers-import.input.js](transforms/ember-test-helper-api-migration/__testfixtures__/do-not-have-ember-test-helpers-import.output.js)</small>):
+**Output** (<small>[do-not-have-ember-test-helpers-import.output.js](transforms/ember-test-helper-api-migration/__testfixtures__/do-not-have-ember-test-helpers-import.output.js)</small>):
 ```js
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
@@ -71,5 +97,93 @@ import hbs from 'htmlbars-inline-precompile';
 moduleForComponent('foo-bar', 'Integration | Component | foo bar', {
   integration: true
 });
+
 ```
-<!--FIXTURE_CONTENT_END-->
+---
+<a id="test-context-specifier">**test-context-specifier**</a>
+
+**Input** (<small>[test-context-specifier.input.js](transforms/ember-test-helper-api-migration/__testfixtures__/test-context-specifier.input.js)</small>):
+```js
+import { click } from '@ember/test-helpers';
+import { TestContext } from 'ember-test-helpers';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+
+module(
+  'Integration | Component | c-pages/recommendations/collections/detail/collection-detail-card-list',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    /** @type {TestContext['setProperties']} */
+    let setProperties;
+
+    hooks.beforeEach(function () {
+      setProperties = this.setProperties;
+
+      this.owner.register(
+        'service:lls-content-library@configuration',
+        ConfigurationStub
+      );
+    });
+
+    test('it renders detail view', async function (assert) {
+      await renderComponent({
+        learningCollectionItems,
+        locale,
+        isEditable: false
+      });
+
+      assert
+        .dom(SELECTORS.DROPDOWN_BUTTON)
+        .doesNotExist(
+          'It does not render dropdown button when `isEditable` is falsey'
+        );
+    });
+  }
+);
+
+```
+
+**Output** (<small>[test-context-specifier.output.js](transforms/ember-test-helper-api-migration/__testfixtures__/test-context-specifier.output.js)</small>):
+```js
+import { click, TestContext } from '@ember/test-helpers';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+
+module(
+  'Integration | Component | c-pages/recommendations/collections/detail/collection-detail-card-list',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    /** @type {TestContext['setProperties']} */
+    let setProperties;
+
+    hooks.beforeEach(function () {
+      setProperties = this.setProperties;
+
+      this.owner.register(
+        'service:lls-content-library@configuration',
+        ConfigurationStub
+      );
+    });
+
+    test('it renders detail view', async function (assert) {
+      await renderComponent({
+        learningCollectionItems,
+        locale,
+        isEditable: false
+      });
+
+      assert
+        .dom(SELECTORS.DROPDOWN_BUTTON)
+        .doesNotExist(
+          'It does not render dropdown button when `isEditable` is falsey'
+        );
+    });
+  }
+);
+
+```
+<!--FIXTURES_CONTENT_END-->

--- a/transforms/ember-test-helper-api-migration/__testfixtures__/test-context-specifier.input.js
+++ b/transforms/ember-test-helper-api-migration/__testfixtures__/test-context-specifier.input.js
@@ -1,0 +1,38 @@
+import { click } from '@ember/test-helpers';
+import { TestContext } from 'ember-test-helpers';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+
+module(
+  'Integration | Component | c-pages/recommendations/collections/detail/collection-detail-card-list',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    /** @type {TestContext['setProperties']} */
+    let setProperties;
+
+    hooks.beforeEach(function () {
+      setProperties = this.setProperties;
+
+      this.owner.register(
+        'service:lls-content-library@configuration',
+        ConfigurationStub
+      );
+    });
+
+    test('it renders detail view', async function (assert) {
+      await renderComponent({
+        learningCollectionItems,
+        locale,
+        isEditable: false
+      });
+
+      assert
+        .dom(SELECTORS.DROPDOWN_BUTTON)
+        .doesNotExist(
+          'It does not render dropdown button when `isEditable` is falsey'
+        );
+    });
+  }
+);

--- a/transforms/ember-test-helper-api-migration/__testfixtures__/test-context-specifier.output.js
+++ b/transforms/ember-test-helper-api-migration/__testfixtures__/test-context-specifier.output.js
@@ -1,0 +1,37 @@
+import { click, TestContext } from '@ember/test-helpers';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+
+module(
+  'Integration | Component | c-pages/recommendations/collections/detail/collection-detail-card-list',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    /** @type {TestContext['setProperties']} */
+    let setProperties;
+
+    hooks.beforeEach(function () {
+      setProperties = this.setProperties;
+
+      this.owner.register(
+        'service:lls-content-library@configuration',
+        ConfigurationStub
+      );
+    });
+
+    test('it renders detail view', async function (assert) {
+      await renderComponent({
+        learningCollectionItems,
+        locale,
+        isEditable: false
+      });
+
+      assert
+        .dom(SELECTORS.DROPDOWN_BUTTON)
+        .doesNotExist(
+          'It does not render dropdown button when `isEditable` is falsey'
+        );
+    });
+  }
+);

--- a/transforms/ember-test-helper-api-migration/index.js
+++ b/transforms/ember-test-helper-api-migration/index.js
@@ -1,9 +1,60 @@
+const { createImportStatement } = require('../utils');
 const { getParser } = require('codemod-cli').jscodeshift;
-const { addImportStatement, writeImportStatements } = require('../utils');
 
 module.exports = function transformer(file, api) {
   const j = getParser(api);
   const root = j(file.source);
+
+  let _statementsToImport = new Set();
+
+  /**
+   * Adds (one or more) named imports to a private import statement collection.
+   * To write the import statements to a file, use writeImportStatements.
+   *
+   * @param j
+   * @param {array} imports
+   */
+  function addImportStatement(imports) {
+    imports.forEach((method) => _statementsToImport.add(method));
+  }
+
+  /**
+   * Adds all collected named imports to an (existing or to be created) `import { namedImport } from '@ember/test-helpers';
+   * To add named imports to the collection, use addImportStatement
+   *
+   * @param j
+   * @param root
+   */
+  function writeImportStatements(j, root) {
+    if (_statementsToImport.size > 0) {
+      let body = root.get().value.program.body;
+      let importStatement = root.find(j.ImportDeclaration, {
+        source: { value: '@ember/test-helpers' },
+      });
+
+      let statementsToImportArray = Array.from(_statementsToImport)
+
+      if (importStatement.length === 0) {
+        importStatement = createImportStatement(
+          j,
+          '@ember/test-helpers',
+          'default',
+          statementsToImportArray
+        );
+        body.unshift(importStatement);
+      } else {
+        let existingSpecifiers = importStatement.get('specifiers');
+
+        statementsToImportArray.forEach((name) => {
+          if (existingSpecifiers.filter((exSp) => exSp.value.imported.name === name).length === 0) {
+            existingSpecifiers.push(j.importSpecifier(j.identifier(name)));
+          }
+        });
+      }
+    }
+
+    _statementsToImport = new Set();
+  }
 
   /**
    * Transform imports from ember-test-helpers to @ember/test-helpers

--- a/transforms/find/README.md
+++ b/transforms/find/README.md
@@ -32,11 +32,11 @@ test('it renders', function(assert) {
 });
 ```
 
-**Output** (<small>[find.input.js](transforms/find/__testfixtures__/find.output.js)</small>):
+**Output** (<small>[find.output.js](transforms/find/__testfixtures__/find.output.js)</small>):
 ```js
 test('it renders', function(assert) {
   assert.equal(this.element.querySelector('.foo').textContent.trim(), 'bar');
   assert.equal(this.element.querySelectorAll('.bar').length, 2);
 });
 ```
-<!--FIXTURE_CONTENT_END-->
+<!--FIXTURES_CONTENT_END-->

--- a/transforms/integration/README.md
+++ b/transforms/integration/README.md
@@ -33,6 +33,7 @@ ember-test-helpers-codemod integration path/of/files/ or/some**/*glob.js
 * [selected](#selected)
 * [set-value](#set-value)
 * [text](#text)
+* [typescript](#typescript)
 <!--FIXTURES_TOC_END-->
 
 <!--FIXTURES_CONTENT_START-->
@@ -82,7 +83,7 @@ test('and again', function(assert) {
 });
 ```
 
-**Output** (<small>[all.input.js](transforms/integration/__testfixtures__/all.output.js)</small>):
+**Output** (<small>[all.output.js](transforms/integration/__testfixtures__/all.output.js)</small>):
 ```js
 import { click, find, findAll, fillIn, blur, triggerEvent } from '@ember/test-helpers';
 import { moduleForComponent, test } from 'ember-qunit';
@@ -146,7 +147,7 @@ test('it renders', function(assert) {
 
 ```
 
-**Output** (<small>[attr.input.js](transforms/integration/__testfixtures__/attr.output.js)</small>):
+**Output** (<small>[attr.output.js](transforms/integration/__testfixtures__/attr.output.js)</small>):
 ```js
 import { find } from '@ember/test-helpers';
 import { moduleForComponent, test } from 'ember-qunit';
@@ -187,7 +188,7 @@ test('it renders', function(assert) {
 
 ```
 
-**Output** (<small>[click.input.js](transforms/integration/__testfixtures__/click.output.js)</small>):
+**Output** (<small>[click.output.js](transforms/integration/__testfixtures__/click.output.js)</small>):
 ```js
 import { find, findAll, click } from '@ember/test-helpers';
 import { moduleForComponent, test } from 'ember-qunit';
@@ -240,9 +241,8 @@ test('it renders', function(assert) {
 
 ```
 
-**Output** (<small>[default-component-test.input.js](transforms/integration/__testfixtures__/default-component-test.output.js)</small>):
+**Output** (<small>[default-component-test.output.js](transforms/integration/__testfixtures__/default-component-test.output.js)</small>):
 ```js
-import { find } from '@ember/test-helpers';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
@@ -257,7 +257,7 @@ test('it renders', function(assert) {
 
   this.render(hbs`{{foo-bar}}`);
 
-  assert.equal(find('*').textContent.trim(), '');
+  assert.equal(this.element.textContent.trim(), '');
 
   // Template block usage:
   this.render(hbs`
@@ -266,7 +266,7 @@ test('it renders', function(assert) {
     {{/foo-barl}}
   `);
 
-  assert.equal(find('*').textContent.trim(), 'template block text');
+  assert.equal(this.element.textContent.trim(), 'template block text');
 });
 
 ```
@@ -316,7 +316,7 @@ test('function callback with one arg', function(assert) {
 
 ```
 
-**Output** (<small>[each.input.js](transforms/integration/__testfixtures__/each.output.js)</small>):
+**Output** (<small>[each.output.js](transforms/integration/__testfixtures__/each.output.js)</small>):
 ```js
 import { findAll } from '@ember/test-helpers';
 import { moduleForComponent, test } from 'ember-qunit';
@@ -392,7 +392,7 @@ test('it renders', function(assert) {
 
 ```
 
-**Output** (<small>[event.input.js](transforms/integration/__testfixtures__/event.output.js)</small>):
+**Output** (<small>[event.output.js](transforms/integration/__testfixtures__/event.output.js)</small>):
 ```js
 import { triggerEvent } from '@ember/test-helpers';
 import { moduleForComponent, test } from 'ember-qunit';
@@ -443,7 +443,7 @@ test('it renders', function(assert) {
 
 ```
 
-**Output** (<small>[focus.input.js](transforms/integration/__testfixtures__/focus.output.js)</small>):
+**Output** (<small>[focus.output.js](transforms/integration/__testfixtures__/focus.output.js)</small>):
 ```js
 import { focus } from '@ember/test-helpers';
 import { moduleForComponent, test } from 'ember-qunit';
@@ -481,7 +481,7 @@ test('it renders', function(assert) {
 
 ```
 
-**Output** (<small>[get-value.input.js](transforms/integration/__testfixtures__/get-value.output.js)</small>):
+**Output** (<small>[get-value.output.js](transforms/integration/__testfixtures__/get-value.output.js)</small>):
 ```js
 import { find } from '@ember/test-helpers';
 import { moduleForComponent, test } from 'ember-qunit';
@@ -518,7 +518,7 @@ test('transforms get() correctly', function(assert) {
 
 ```
 
-**Output** (<small>[get.input.js](transforms/integration/__testfixtures__/get.output.js)</small>):
+**Output** (<small>[get.output.js](transforms/integration/__testfixtures__/get.output.js)</small>):
 ```js
 import { findAll } from '@ember/test-helpers';
 import { moduleForComponent, test } from 'ember-qunit';
@@ -555,7 +555,7 @@ test('it renders', function(assert) {
 
 ```
 
-**Output** (<small>[has-class.input.js](transforms/integration/__testfixtures__/has-class.output.js)</small>):
+**Output** (<small>[has-class.output.js](transforms/integration/__testfixtures__/has-class.output.js)</small>):
 ```js
 import { find } from '@ember/test-helpers';
 import { moduleForComponent, test } from 'ember-qunit';
@@ -596,7 +596,7 @@ test('it renders', function(assert) {
 
 ```
 
-**Output** (<small>[html.input.js](transforms/integration/__testfixtures__/html.output.js)</small>):
+**Output** (<small>[html.output.js](transforms/integration/__testfixtures__/html.output.js)</small>):
 ```js
 import { find } from '@ember/test-helpers';
 import { moduleForComponent, test } from 'ember-qunit';
@@ -657,12 +657,14 @@ test('it renders', function(assert) {
   assert.ok(this.$('.foo:radio').length);
   assert.ok(this.$('.foo:reset').length);
   assert.ok(this.$('.foo:selected').length);
+  assert.ok(this.$(':selected').length);
   assert.ok(this.$('.foo:submit').length);
   assert.ok(this.$('.foo:text').length);
   assert.ok(this.$('.foo:visible').length);
   assert.ok(this.$(JQEXTENSION_SELECTOR_AS_LOCAL_CONST).length);
   assert.ok(this.$(ANY_SELECTOR_AS_IMPORTED_CONST).length);
 
+  assert.ok(this.$(':eq(0)').length);
   assert.ok(this.$('.foo:eq(0)').length);
   assert.ok(this.$('.foo:eq(1)').length);
   assert.ok(this.$('.foo:first-child').length);
@@ -673,7 +675,7 @@ test('it renders', function(assert) {
 
 ```
 
-**Output** (<small>[jq-extensions.input.js](transforms/integration/__testfixtures__/jq-extensions.output.js)</small>):
+**Output** (<small>[jq-extensions.output.js](transforms/integration/__testfixtures__/jq-extensions.output.js)</small>):
 ```js
 import { find, findAll } from '@ember/test-helpers';
 import { moduleForComponent, test } from 'ember-qunit';
@@ -711,12 +713,14 @@ test('it renders', function(assert) {
   assert.ok(this.$('.foo:radio').length);
   assert.ok(this.$('.foo:reset').length);
   assert.ok(findAll('.foo:checked').length);
+  assert.ok(this.$(':selected').length);
   assert.ok(this.$('.foo:submit').length);
   assert.ok(this.$('.foo:text').length);
   assert.ok(this.$('.foo:visible').length);
   assert.ok(this.$(JQEXTENSION_SELECTOR_AS_LOCAL_CONST).length);
   assert.ok(this.$(ANY_SELECTOR_AS_IMPORTED_CONST).length);
 
+  assert.ok(this.$(':eq(0)').length);
   assert.ok(findAll(find('.foo')).length);
   assert.ok(findAll('.foo')[1].length);
   assert.ok(findAll('.foo:first-child').length);
@@ -747,7 +751,7 @@ test('it renders', function(assert) {
 
 ```
 
-**Output** (<small>[key-event.input.js](transforms/integration/__testfixtures__/key-event.output.js)</small>):
+**Output** (<small>[key-event.output.js](transforms/integration/__testfixtures__/key-event.output.js)</small>):
 ```js
 import { keyEvent } from '@ember/test-helpers';
 import { moduleForComponent, test } from 'ember-qunit';
@@ -785,7 +789,7 @@ test('it renders', function(assert) {
 
 ```
 
-**Output** (<small>[length.input.js](transforms/integration/__testfixtures__/length.output.js)</small>):
+**Output** (<small>[length.output.js](transforms/integration/__testfixtures__/length.output.js)</small>):
 ```js
 import { findAll } from '@ember/test-helpers';
 import { moduleForComponent, test } from 'ember-qunit';
@@ -822,7 +826,7 @@ test('it renders', function(assert) {
 
 ```
 
-**Output** (<small>[prop.input.js](transforms/integration/__testfixtures__/prop.output.js)</small>):
+**Output** (<small>[prop.output.js](transforms/integration/__testfixtures__/prop.output.js)</small>):
 ```js
 import { find } from '@ember/test-helpers';
 import { moduleForComponent, test } from 'ember-qunit';
@@ -868,7 +872,7 @@ test(':selected is replaced correctly', function(assert) {
 
 ```
 
-**Output** (<small>[selected.input.js](transforms/integration/__testfixtures__/selected.output.js)</small>):
+**Output** (<small>[selected.output.js](transforms/integration/__testfixtures__/selected.output.js)</small>):
 ```js
 import { find, findAll } from '@ember/test-helpers';
 import { moduleForComponent, test } from 'ember-qunit';
@@ -917,12 +921,20 @@ test('it renders', function(assert) {
   Ember.run(() => this.$('select').val('1').trigger('change'));
   Ember.run(() => this.$('#odd').val(10).trigger('input').trigger('blur'));
   this.$('#odd').val(10).trigger('input').trigger('blur');
+  this.$('input:eq(0)')
+    .val('foo')
+    .trigger('keydown')
+    .focusout();
+  this.$('input:eq(0)')
+    .val('foo')
+    .trigger('keydown')
+    .blur();
   assert.ok(true);
 });
 
 ```
 
-**Output** (<small>[set-value.input.js](transforms/integration/__testfixtures__/set-value.output.js)</small>):
+**Output** (<small>[set-value.output.js](transforms/integration/__testfixtures__/set-value.output.js)</small>):
 ```js
 import { fillIn, blur } from '@ember/test-helpers';
 import Ember from 'ember';
@@ -944,6 +956,14 @@ test('it renders', async function(assert) {
   Ember.run(() => this.$('select').val('1').trigger('change'));
   Ember.run(() => this.$('#odd').val(10).trigger('input').trigger('blur'));
   this.$('#odd').val(10).trigger('input').trigger('blur');
+  this.$('input:eq(0)')
+    .val('foo')
+    .trigger('keydown')
+    .focusout();
+  this.$('input:eq(0)')
+    .val('foo')
+    .trigger('keydown')
+    .blur();
   assert.ok(true);
 });
 
@@ -966,9 +986,15 @@ test('it renders', function(assert) {
   assert.equal(this.$('.foo').text().trim(), '');
 });
 
+test('it renders', function(assert) {
+  this.render(hbs`{{foo-bar}}`);
+
+  assert.equal(this.$().text().trim(), '');
+});
+
 ```
 
-**Output** (<small>[text.input.js](transforms/integration/__testfixtures__/text.output.js)</small>):
+**Output** (<small>[text.output.js](transforms/integration/__testfixtures__/text.output.js)</small>):
 ```js
 import { find } from '@ember/test-helpers';
 import { moduleForComponent, test } from 'ember-qunit';
@@ -984,5 +1010,102 @@ test('it renders', function(assert) {
   assert.equal(find('.foo').textContent.trim(), '');
 });
 
+test('it renders', function(assert) {
+  this.render(hbs`{{foo-bar}}`);
+
+  assert.equal(this.element.textContent.trim(), '');
+});
+
 ```
-<!--FIXTURE_CONTENT_END-->
+---
+<a id="typescript">**typescript**</a>
+
+**Input** (<small>[typescript.input.ts](transforms/integration/__testfixtures__/typescript.input.ts)</small>):
+```ts
+import { click } from '@ember/test-helpers';
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('foo-bar', 'Integration | Component | foo bar', {
+  integration: true
+});
+
+function fillInHelper(value: string) {
+  this.$('.foo input').val(value);
+  this.$('.foo input').change();
+}
+
+test('it renders', async function(assert) {
+  this.render(hbs`{{foo-bar}}`);
+
+  await click('.foo');
+  assert.equal(this.$('.foo').attr('id'), 'foo');
+  this.$('.foo input').val('bar').change();
+  assert.equal(this.$('.foo').text().trim(), 'foo');
+});
+
+test('it renders again', function(assert) {
+  this.render(hbs`{{foo-bar}}`);
+
+  let selector = '.foo input';
+  assert.equal(this.$(selector).length, 1);
+  assert.equal(this.$(selector).val(), 'foo');
+  assert.ok(this.$('.foo').hasClass('selected'));
+});
+
+test('and again', function(assert) {
+  this.render(hbs`{{foo-bar}}`);
+
+  this.$('foo').click();
+
+  fillInHelper.call(this, 'bar');
+  assert.ok(this.$('.foo').hasClass('selected'));
+});
+
+```
+
+**Output** (<small>[typescript.output.ts](transforms/integration/__testfixtures__/typescript.output.ts)</small>):
+```ts
+import { click, find, findAll, fillIn, blur, triggerEvent } from '@ember/test-helpers';
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('foo-bar', 'Integration | Component | foo bar', {
+  integration: true
+});
+
+async function fillInHelper(value: string) {
+  await fillIn('.foo input', value);
+  await triggerEvent('.foo input', 'change');
+}
+
+test('it renders', async function(assert) {
+  this.render(hbs`{{foo-bar}}`);
+
+  await click('.foo');
+  assert.equal(find('.foo').id, 'foo');
+  await fillIn('.foo input', 'bar');
+  await blur('.foo input');
+  assert.equal(find('.foo').textContent.trim(), 'foo');
+});
+
+test('it renders again', function(assert) {
+  this.render(hbs`{{foo-bar}}`);
+
+  let selector = '.foo input';
+  assert.equal(findAll(selector).length, 1);
+  assert.equal(find(selector).value, 'foo');
+  assert.ok(find('.foo').classList.contains('selected'));
+});
+
+test('and again', async function(assert) {
+  this.render(hbs`{{foo-bar}}`);
+
+  await click('foo');
+
+  fillInHelper.call(this, 'bar');
+  assert.ok(find('.foo').classList.contains('selected'));
+});
+
+```
+<!--FIXTURES_CONTENT_END-->

--- a/transforms/native-dom/README.md
+++ b/transforms/native-dom/README.md
@@ -16,6 +16,7 @@ ember-test-helpers-codemod native-dom path/of/files/ or/some**/*glob.js
 
 <!--FIXTURES_TOC_START-->
 * [acceptance](#acceptance)
+* [context-argument](#context-argument)
 * [double-import](#double-import)
 * [integration](#integration)
 * [prune-import](#prune-import)
@@ -52,7 +53,7 @@ test('visiting /bar', async function(assert) {
 
 ```
 
-**Output** (<small>[acceptance.input.js](transforms/native-dom/__testfixtures__/acceptance.output.js)</small>):
+**Output** (<small>[acceptance.output.js](transforms/native-dom/__testfixtures__/acceptance.output.js)</small>):
 ```js
 import { find, visit, currentURL, currentRouteName } from '@ember/test-helpers';
 import { currentPath } from 'ember-native-dom-helpers';
@@ -79,6 +80,60 @@ test('visiting /bar', async function(assert) {
 
 ```
 ---
+<a id="context-argument">**context-argument**</a>
+
+**Input** (<small>[context-argument.input.js](transforms/native-dom/__testfixtures__/context-argument.input.js)</small>):
+```js
+import { find, findAll, visit, click, fillIn } from 'ember-native-dom-helpers';
+import { test } from 'qunit';
+import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+
+moduleForAcceptance('click');
+
+test('visiting /foo', async function(assert) {
+  await visit('/foo');
+
+  const foo = find('.foo');
+  assert.equal(find('.bar', foo).textContent.trim(), 'bar');
+  assert.equal(find('.bar', find('.foo')).textContent.trim(), 'bar');
+  assert.equal(find('.bar', '.foo').textContent.trim(), 'bar');
+  assert.equal(findAll('.bar', foo).length, 2);
+  assert.equal(findAll('.bar', find('.foo')).length, 2);
+  assert.equal(findAll('.bar', '.foo').length, 2);
+
+  await click('button', foo);
+  await click('button', { shiftKey: true });
+  await click('button', foo, { shiftKey: true });
+});
+
+```
+
+**Output** (<small>[context-argument.output.js](transforms/native-dom/__testfixtures__/context-argument.output.js)</small>):
+```js
+import { find, findAll, visit, click } from '@ember/test-helpers';
+import { test } from 'qunit';
+import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+
+moduleForAcceptance('click');
+
+test('visiting /foo', async function(assert) {
+  await visit('/foo');
+
+  const foo = find('.foo');
+  assert.equal(foo.querySelector('.bar').textContent.trim(), 'bar');
+  assert.equal(find('.foo').querySelector('.bar').textContent.trim(), 'bar');
+  assert.equal(find('.foo .bar').textContent.trim(), 'bar');
+  assert.equal(foo.querySelectorAll('.bar').length, 2);
+  assert.equal(find('.foo').querySelectorAll('.bar').length, 2);
+  assert.equal(findAll('.foo .bar').length, 2);
+
+  await click(foo.querySelector('button'));
+  await click('button', { shiftKey: true });
+  await click(foo.querySelector('button'), { shiftKey: true });
+});
+
+```
+---
 <a id="double-import">**double-import**</a>
 
 **Input** (<small>[double-import.input.js](transforms/native-dom/__testfixtures__/double-import.input.js)</small>):
@@ -86,11 +141,25 @@ test('visiting /bar', async function(assert) {
 import { click, currentURL } from 'ember-native-dom-helpers';
 import { find, visit } from 'ember-native-dom-helpers';
 
+test('visiting /foo', async function(assert) {
+  await visit('/foo');
+  await click('.foo');
+  assert.ok(find('.foo'));
+  assert.ok(currentURL());
+});
+
 ```
 
-**Output** (<small>[double-import.input.js](transforms/native-dom/__testfixtures__/double-import.output.js)</small>):
+**Output** (<small>[double-import.output.js](transforms/native-dom/__testfixtures__/double-import.output.js)</small>):
 ```js
 import { click, currentURL, find, visit } from '@ember/test-helpers';
+
+test('visiting /foo', async function(assert) {
+  await visit('/foo');
+  await click('.foo');
+  assert.ok(find('.foo'));
+  assert.ok(currentURL());
+});
 
 ```
 ---
@@ -167,7 +236,7 @@ test('and yet again', async function(assert) {
 
 ```
 
-**Output** (<small>[integration.input.js](transforms/native-dom/__testfixtures__/integration.output.js)</small>):
+**Output** (<small>[integration.output.js](transforms/native-dom/__testfixtures__/integration.output.js)</small>):
 ```js
 import {
   click,
@@ -243,11 +312,15 @@ test('and yet again', async function(assert) {
 ```js
 import { click } from 'ember-native-dom-helpers';
 
+click('.foo');
+
 ```
 
-**Output** (<small>[prune-import.input.js](transforms/native-dom/__testfixtures__/prune-import.output.js)</small>):
+**Output** (<small>[prune-import.output.js](transforms/native-dom/__testfixtures__/prune-import.output.js)</small>):
 ```js
 import { click } from '@ember/test-helpers';
 
+click('.foo');
+
 ```
-<!--FIXTURE_CONTENT_END-->
+<!--FIXTURES_CONTENT_END-->

--- a/transforms/this-render-migration/README.md
+++ b/transforms/this-render-migration/README.md
@@ -37,7 +37,7 @@ test('It handles switching selected option on click and fires onSelect event', a
 
 ```
 
-**Output** (<small>[basic.input.js](transforms/this-render-migration/__testfixtures__/basic.output.js)</small>):
+**Output** (<small>[basic.output.js](transforms/this-render-migration/__testfixtures__/basic.output.js)</small>):
 ```js
 import { click, render } from '@ember/test-helpers';
 
@@ -48,6 +48,7 @@ test('It handles switching selected option on click and fires onSelect event', a
       </Common::TimeCommitmentSelector>
     `);
 })
+
 ```
 ---
 <a id="has-no-ember-test-helpers-import">**has-no-ember-test-helpers-import**</a>
@@ -64,7 +65,7 @@ test('It handles switching selected option on click and fires onSelect event', a
 
 ```
 
-**Output** (<small>[has-no-ember-test-helpers-import.input.js](transforms/this-render-migration/__testfixtures__/has-no-ember-test-helpers-import.output.js)</small>):
+**Output** (<small>[has-no-ember-test-helpers-import.output.js](transforms/this-render-migration/__testfixtures__/has-no-ember-test-helpers-import.output.js)</small>):
 ```js
 import { render } from '@ember/test-helpers';
 test('It handles switching selected option on click and fires onSelect event', async function(assert) {
@@ -76,4 +77,4 @@ test('It handles switching selected option on click and fires onSelect event', a
 })
 
 ```
-<!--FIXTURE_CONTENT_END-->
+<!--FIXTURES_CONTENT_END-->

--- a/transforms/update-triggerevent-file-param/README.md
+++ b/transforms/update-triggerevent-file-param/README.md
@@ -33,7 +33,7 @@ test('test', async function(assert) {
 
 ```
 
-**Output** (<small>[basic.input.js](transforms/update-triggerevent-file-param/__testfixtures__/basic.output.js)</small>):
+**Output** (<small>[basic.output.js](transforms/update-triggerevent-file-param/__testfixtures__/basic.output.js)</small>):
 ```js
 import { triggerEvent } from '@ember/test-helpers';
 
@@ -47,4 +47,4 @@ test('test', async function(assert) {
 });
 
 ```
-<!--FIXTURE_CONTENT_END-->
+<!--FIXTURES_CONTENT_END-->

--- a/transforms/utils.js
+++ b/transforms/utils.js
@@ -552,6 +552,7 @@ module.exports = {
   isFindExpression,
   createFindExpression,
   createFindAllExpression,
+  createImportStatement,
   createQuerySelectorExpression,
   createQuerySelectorAllExpression,
   createClickExpression,


### PR DESCRIPTION
Previous `ember-test-helper-api-migration` transform does not support the following case:
From
```js
import { click } from '@ember/test-helpers';
import { TestContext } from 'ember-test-helpers';

    /** @type {TestContext['setProperties']} */
    let setProperties;
```
To
```js
import { click, TestContext } from '@ember/test-helpers';

    /** @type {TestContext['setProperties']} */
    let setProperties;
```
Because there is no `CallExpression` contain `TestContext`, the `TestContext` specifier would be filtered by https://github.com/ember-codemods/ember-test-helpers-codemod/blob/master/transforms/utils.js#L366


This PR will fix above issue and update the README for this repo.